### PR TITLE
rate for h264 is sent 0 from viconnet gateway, setting to default 90000

### DIFF
--- a/subprojects/gst-plugins-base/gst-libs/gst/sdp/gstsdpmessage.c
+++ b/subprojects/gst-plugins-base/gst-libs/gst/sdp/gstsdpmessage.c
@@ -3622,7 +3622,7 @@ gst_sdp_media_get_caps_from_media (const GstSDPMedia * media, gint pt)
 
   /* check if we have a rate, if not, we need to look up the rate from the
    * default rates based on the payload types. */
-  if (rate == -1) {
+  if (rate == -1 || rate == 0) {
     const GstRTPPayloadInfo *info;
 
     if (GST_RTP_PAYLOAD_IS_DYNAMIC (pt)) {
@@ -3642,9 +3642,6 @@ gst_sdp_media_get_caps_from_media (const GstSDPMedia * media, gint pt)
     /* we fail if we cannot find one */
     if (rate == -1)
       goto no_rate;
-
-    if (rate == 0 && name != NULL && (!g_strcmp0(name,"h264") || !g_strcmp0(name,"H264")))
-      rate = 90000;
   }
 
   tmp = g_ascii_strdown (media->media, -1);

--- a/subprojects/gst-plugins-base/gst-libs/gst/sdp/gstsdpmessage.c
+++ b/subprojects/gst-plugins-base/gst-libs/gst/sdp/gstsdpmessage.c
@@ -3642,6 +3642,9 @@ gst_sdp_media_get_caps_from_media (const GstSDPMedia * media, gint pt)
     /* we fail if we cannot find one */
     if (rate == -1)
       goto no_rate;
+
+    if (rate == 0 && name != NULL && (!g_strcmp0(name,"h264") || !g_strcmp0(name,"H264")))
+      rate = 90000;
   }
 
   tmp = g_ascii_strdown (media->media, -1);


### PR DESCRIPTION
Viconnet gateway is sending Clock rate for h264 with value 0. Gstreamer is handling the scenario where the clock rate is not sent it is set to default value of 90000. Since viconnet gateway is sending specifically 0 its mismatching the caps and streaming is failed. Setting the default value when 0 is sent for clock rate.