### PR TITLE
Clear h264 decoder DPB when bumping fails

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gsth264decoder.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gsth264decoder.c
@@ -926,6 +926,7 @@ _bump_dpb (GstH264Decoder * self, GstH264DpbBumpMode bump_level,
 
     if (!to_output) {
       GST_WARNING_OBJECT (self, "Bumping is needed but no picture to output");
+      gst_h264_decoder_clear_dpb (self, TRUE);
       break;
     }
 


### PR DESCRIPTION
This change prevents the stuck on corrupted h264 straems.

A corrupted stream might lead to overload in DPD (Decoded Picture Buffer) and occupying whole buffer pool. Later any new buffer cannot be created what resulted in deadlock in the decoder while waiting for a buffer wfom buffer pool.

This change will make the current GOP unplayable but it's a safe way for avoiding deadlock on errogenous streams.