### PR TITLE
WTC-1213-Debug-Crash

### DIFF
--- a/subprojects/gstreamer/gst/gstinfo.c
+++ b/subprojects/gstreamer/gst/gstinfo.c
@@ -317,7 +317,6 @@ typedef struct
 LogFuncEntry;
 static GMutex __log_func_mutex;
 static GSList *__log_functions = NULL;
-FILE *log_file = NULL;
 
 /* whether to add the default log function in gst_init() */
 static gboolean add_default_log_func = TRUE;
@@ -361,6 +360,7 @@ void
 _priv_gst_debug_init (void)
 {
   const gchar *env;
+  FILE *log_file = NULL;
 
   if (add_default_log_func) {
     env = g_getenv ("GST_DEBUG_FILE");
@@ -1537,10 +1537,9 @@ gst_debug_remove_with_compare_func (GCompareFunc func, gpointer data)
 
     if (entry->notify)
       entry->notify (entry->user_data);
-	if (entry->user_data == log_file) {
-		fclose(log_file);
-		log_file = NULL;
-	}
+    if ((entry->user_data != stderr) && (entry->user_data != stdout)) {
+      fclose (entry->user_data);
+    }
     g_slice_free (LogFuncEntry, entry);
     cleanup = g_slist_delete_link (cleanup, cleanup);
   }
@@ -2293,8 +2292,6 @@ _priv_gst_debug_cleanup (void)
     g_slice_free (LogFuncEntry, log_func_entry);
     __log_functions = g_slist_delete_link (__log_functions, __log_functions);
   }
-  if (log_file != NULL)
-	  fclose(log_file);
   g_mutex_unlock (&__log_func_mutex);
 }
 


### PR DESCRIPTION
Close file handles in gstreamer to avoid conflict of C Library used by application and GLib