### PR TITLE
d3d11decoder: avoid crash if the input state is null

### DIFF
--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11decoder.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11decoder.cpp
@@ -1686,6 +1686,11 @@ gst_d3d11_decoder_negotiate (GstD3D11Decoder * decoder,
   info = &decoder->output_info;
   input_state = decoder->input_state;
 
+  if (input_state == nullptr) {
+    GST_WARNING_OBJECT (videodec, "Input state is null");
+    return FALSE;
+  }
+
   alternate_interlaced =
       (GST_VIDEO_INFO_INTERLACE_MODE (info) ==
       GST_VIDEO_INTERLACE_MODE_ALTERNATE);


### PR DESCRIPTION
It arrived to that crash after gst_d3d11_decoder_open() failure: gst_d3d11_decoder_open() resets the input state on error.