### PR TITLE
Fix d3d11videosink query vs stop race condition

### DIFF
--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11videosink.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11videosink.cpp
@@ -1085,6 +1085,7 @@ gst_d3d11_video_sink_propose_allocation (GstBaseSink * sink, GstQuery * query)
   guint size;
   gboolean need_pool;
 
+  GstD3D11CSLockGuard lk (&self->lock);
   if (!self->device)
     return FALSE;
 
@@ -1195,11 +1196,14 @@ gst_d3d11_video_sink_query (GstBaseSink * sink, GstQuery * query)
 
   switch (GST_QUERY_TYPE (query)) {
     case GST_QUERY_CONTEXT:
+    {
+      GstD3D11CSLockGuard lk (&self->lock);
       if (gst_d3d11_handle_context_query (GST_ELEMENT (self), query,
               self->device)) {
         return TRUE;
       }
       break;
+    }
     default:
       break;
   }


### PR DESCRIPTION
During the testing we caught this critical warning, that in fact represents a dangerous race condition:

gst_d3d11_buffer_pool_new: assertion 'GST_IS_D3D11_DEVICE (device)' failed

The thing is that gst_d3d11_video_sink_stop() may be called while the allocation query is in proccess, so some resources of the sink get freed while the bufferpool is in the preparation. This can leak a bufferpool, use freed objects and so on.