### PR TITLE
d3d11device: handle DXGI_ERROR_DEVICE_REMOVED

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.cpp
@@ -92,6 +92,15 @@ enum
 #define DEFAULT_ADAPTER 0
 #define DEFAULT_CREATE_FLAGS 0
 
+enum
+{
+  /* signals */
+  SIGNAL_SUSPENDED,
+  LAST_SIGNAL
+};
+
+static guint gst_d3d11_device_signals[LAST_SIGNAL] = { 0, };
+
 struct _GstD3D11DevicePrivate
 {
   guint adapter;
@@ -101,6 +110,7 @@ struct _GstD3D11DevicePrivate
   gchar *description;
   guint create_flags;
   gint64 adapter_luid;
+  gboolean suspended;
 
   ID3D11Device *device;
   ID3D11Device5 *device5;
@@ -394,6 +404,20 @@ gst_d3d11_device_class_init (GstD3D11DeviceClass * klass)
       g_param_spec_int64 ("adapter-luid", "Adapter LUID",
           "DXGI Adapter LUID (Locally Unique Identifier) of created device",
           G_MININT64, G_MAXINT64, 0, readable_flags));
+
+  /**
+   * GstD3D11Device::suspended:
+   * @device: the #d3d11device
+   *
+   * Emitted when the D3D11Device gets suspended by the DirectX (error
+   * DXGI_ERROR_DEVICE_REMOVED have been returned from some of the DirectX
+   * operations).
+   *
+   * Since: cemtrex patch to 1.22.4
+   */
+  gst_d3d11_device_signals[SIGNAL_SUSPENDED] =
+    g_signal_new ("suspended", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST,
+      0, NULL, NULL, NULL, G_TYPE_NONE, 0, G_TYPE_NONE);
 
   gst_d3d11_memory_init_once ();
 }
@@ -1394,6 +1418,28 @@ gst_d3d11_device_get_format (GstD3D11Device * device, GstVideoFormat format,
     gst_d3d11_format_init (device_format);
 
   return FALSE;
+}
+
+void
+gst_d3d11_device_mark_suspended (GstD3D11Device* device)
+{
+  g_return_if_fail (GST_IS_D3D11_DEVICE (device));
+
+  if (!device->priv->suspended) {
+    HRESULT reason;
+    gchar* error_text = NULL;
+
+    reason = device->priv->device->GetDeviceRemovedReason ();
+    error_text = g_win32_error_message ((guint)reason);
+    GST_ERROR_OBJECT (device, "D3D11Device have been suspended. Reason: 0x%x, %s",
+      reason, error_text);
+    g_critical ("D3D11Device suspended");
+    g_free (error_text);
+
+    g_signal_emit (device, gst_d3d11_device_signals[SIGNAL_SUSPENDED], 0,
+      NULL);
+    device->priv->suspended = TRUE;
+  }
 }
 
 GST_DEFINE_MINI_OBJECT_TYPE (GstD3D11Fence, gst_d3d11_fence);

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.h
@@ -119,6 +119,9 @@ gboolean              gst_d3d11_device_get_format         (GstD3D11Device * devi
                                                            GstVideoFormat format,
                                                            GstD3D11Format * device_format);
 
+/* Used internally by gstd3d11utils.cpp */
+void                  gst_d3d11_device_mark_suspended     (GstD3D11Device* device);
+
 /**
  * GstD3D11Fence:
  *

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11utils.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11utils.cpp
@@ -568,6 +568,11 @@ gboolean
 _gst_d3d11_result (HRESULT hr, GstD3D11Device * device, GstDebugCategory * cat,
     const gchar * file, const gchar * function, gint line)
 {
+  if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
+  {
+    gst_d3d11_device_mark_suspended (device);
+  }
+
 #ifndef GST_DISABLE_GST_DEBUG
   gboolean ret = TRUE;
 


### PR DESCRIPTION
This is the first step of the patch. When the error is cought the GstD3D11Device object raises the new "suspended" signal. This allow handling the error from outside: replace the catched GstContext by the new one.
On the second step, GstD3D11Device will also manage to stop the playback by returning NULL intead of the real handles, but this will require to add changes to each plugin that uses GstD3D11Device, otherwise it can crash accessing the NULL pointer.