### PR TITLE
d3d11: fix memory corruption reported by d3d11debuglayer

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.cpp
@@ -92,6 +92,15 @@ enum
 #define DEFAULT_ADAPTER 0
 #define DEFAULT_CREATE_FLAGS 0
 
+enum
+{
+  /* signals */
+  SIGNAL_SUSPENDED,
+  LAST_SIGNAL
+};
+
+static guint gst_d3d11_device_signals[LAST_SIGNAL] = { 0, };
+
 struct _GstD3D11DevicePrivate
 {
   guint adapter;
@@ -101,6 +110,7 @@ struct _GstD3D11DevicePrivate
   gchar *description;
   guint create_flags;
   gint64 adapter_luid;
+  gboolean suspended;
 
   ID3D11Device *device;
   ID3D11Device5 *device5;
@@ -394,6 +404,20 @@ gst_d3d11_device_class_init (GstD3D11DeviceClass * klass)
       g_param_spec_int64 ("adapter-luid", "Adapter LUID",
           "DXGI Adapter LUID (Locally Unique Identifier) of created device",
           G_MININT64, G_MAXINT64, 0, readable_flags));
+
+  /**
+   * GstD3D11Device::suspended:
+   * @device: the #d3d11device
+   *
+   * Emitted when the D3D11Device gets suspended by the DirectX (error
+   * DXGI_ERROR_DEVICE_REMOVED have been returned from some of the DirectX
+   * operations).
+   *
+   * Since: cemtrex patch to 1.22.4
+   */
+  gst_d3d11_device_signals[SIGNAL_SUSPENDED] =
+    g_signal_new ("suspended", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST,
+      0, NULL, NULL, NULL, G_TYPE_NONE, 0, G_TYPE_NONE);
 
   gst_d3d11_memory_init_once ();
 }
@@ -1394,6 +1418,28 @@ gst_d3d11_device_get_format (GstD3D11Device * device, GstVideoFormat format,
     gst_d3d11_format_init (device_format);
 
   return FALSE;
+}
+
+void
+gst_d3d11_device_mark_suspended (GstD3D11Device* device)
+{
+  g_return_if_fail (GST_IS_D3D11_DEVICE (device));
+
+  if (!device->priv->suspended) {
+    HRESULT reason;
+    gchar* error_text = NULL;
+
+    reason = device->priv->device->GetDeviceRemovedReason ();
+    error_text = g_win32_error_message ((guint)reason);
+    GST_ERROR_OBJECT (device, "D3D11Device have been suspended. Reason: 0x%x, %s",
+      reason, error_text);
+    g_critical ("D3D11Device suspended");
+    g_free (error_text);
+
+    g_signal_emit (device, gst_d3d11_device_signals[SIGNAL_SUSPENDED], 0,
+      NULL);
+    device->priv->suspended = TRUE;
+  }
 }
 
 GST_DEFINE_MINI_OBJECT_TYPE (GstD3D11Fence, gst_d3d11_fence);

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.h
@@ -119,6 +119,9 @@ gboolean              gst_d3d11_device_get_format         (GstD3D11Device * devi
                                                            GstVideoFormat format,
                                                            GstD3D11Format * device_format);
 
+/* Used internally by gstd3d11utils.cpp */
+void                  gst_d3d11_device_mark_suspended     (GstD3D11Device* device);
+
 /**
  * GstD3D11Fence:
  *

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
@@ -1467,14 +1467,13 @@ gst_d3d11_allocator_free (GstAllocator * allocator, GstMemory * mem)
   GST_D3D11_CLEAR_COM (dmem_priv->decoder_output_view);
   GST_D3D11_CLEAR_COM (dmem_priv->processor_input_view);
   GST_D3D11_CLEAR_COM (dmem_priv->processor_output_view);
+  GST_D3D11_CLEAR_COM (dmem_priv->dxgi_surface);
+  GST_D3D11_CLEAR_COM (dmem_priv->d2d1_render_target);
   GST_D3D11_CLEAR_COM (dmem_priv->texture);
   GST_D3D11_CLEAR_COM (dmem_priv->staging);
   GST_D3D11_CLEAR_COM (dmem_priv->buffer);
 
   GST_D3D11_CLEAR_COM (dmem_priv->decoder_handle);
-
-  GST_D3D11_CLEAR_COM (dmem_priv->dxgi_surface);
-  GST_D3D11_CLEAR_COM (dmem_priv->d2d1_render_target);
 
   gst_clear_object (&dmem->device);
 

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
@@ -1046,6 +1046,7 @@ gst_d3d11_memory_ensure_decoder_output_view (GstD3D11Memory * mem,
 
   GstD3D11SRWLockGuard lk (GST_D3D11_MEMORY_GET_LOCK (mem));
   if (dmem_priv->decoder_output_view) {
+    GstD3D11DeviceLockGuard lkd (mem->device);
     dmem_priv->decoder_output_view->GetDesc (&desc);
     if (IsEqualGUID (desc.DecodeProfile, *decoder_profile) &&
         dmem_priv->decoder_handle == decoder) {

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11utils.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11utils.cpp
@@ -568,6 +568,11 @@ gboolean
 _gst_d3d11_result (HRESULT hr, GstD3D11Device * device, GstDebugCategory * cat,
     const gchar * file, const gchar * function, gint line)
 {
+  if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
+  {
+    gst_d3d11_device_mark_suspended (device);
+  }
+
 #ifndef GST_DISABLE_GST_DEBUG
   gboolean ret = TRUE;
 

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11convert.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11convert.cpp
@@ -1248,7 +1248,11 @@ gst_d3d11_base_convert_propose_allocation (GstBaseTransform * trans,
   }
 
   device_handle = gst_d3d11_device_get_device_handle (filter->device);
+
+  gst_d3d11_device_lock (filter->device);
   hr = device_handle->CheckFormatSupport (dxgi_format, &supported);
+  gst_d3d11_device_unlock (filter->device);
+
   if (gst_d3d11_result (hr, filter->device) &&
       (supported & D3D11_FORMAT_SUPPORT_RENDER_TARGET) ==
       D3D11_FORMAT_SUPPORT_RENDER_TARGET) {
@@ -1370,7 +1374,9 @@ gst_d3d11_base_convert_decide_allocation (GstBaseTransform * trans,
   }
 
   device_handle = gst_d3d11_device_get_device_handle (filter->device);
+  gst_d3d11_device_lock (filter->device);
   hr = device_handle->CheckFormatSupport (dxgi_format, &supported);
+  gst_d3d11_device_unlock (filter->device);
   if (gst_d3d11_result (hr, filter->device) &&
       (supported & D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) ==
       D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) {

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11crop.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11crop.cpp
@@ -638,7 +638,11 @@ gst_d3d11_crop_decide_allocation(GstBaseTransform* trans, GstQuery* query)
     }
 
     device_handle = gst_d3d11_device_get_device_handle(filter->device);
+
+    gst_d3d11_device_lock (filter->device);
     hr = device_handle->CheckFormatSupport(dxgi_format, &supported);
+    gst_d3d11_device_unlock (filter->device);
+
     if (gst_d3d11_result(hr, filter->device)) {
         if ((supported & D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) ==
             D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) {

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11d2d1.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11d2d1.cpp
@@ -301,7 +301,10 @@ gst_d3d11_d2d1_decide_allocation(GstBaseTransform* trans, GstQuery* query)
 
     device_handle = gst_d3d11_device_get_device_handle(filter->device);
 
+    gst_d3d11_device_lock (filter->device);
     hr = device_handle->CheckFormatSupport(dxgi_format, &supported);
+    gst_d3d11_device_lock (filter->device);
+
     if (gst_d3d11_result(hr, filter->device)) {
         if ((supported & D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) !=
             D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) {

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11decoder.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11decoder.cpp
@@ -1459,8 +1459,6 @@ gst_d3d11_decoder_get_output_view_from_buffer (GstD3D11Decoder * decoder,
     return NULL;
   }
 
-  GstD3D11DeviceLockGuard lk (decoder->device);
-
   dmem = (GstD3D11Memory *) mem;
   view = gst_d3d11_memory_get_decoder_output_view (dmem, decoder->video_device,
       decoder->decoder_handle, &decoder->decoder_profile);

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11upload.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11upload.cpp
@@ -334,7 +334,11 @@ gst_d3d11_upload_decide_allocation (GstBaseTransform * trans, GstQuery * query)
   }
 
   device_handle = gst_d3d11_device_get_device_handle (filter->device);
+
+  gst_d3d11_device_lock (filter->device);
   hr = device_handle->CheckFormatSupport (dxgi_format, &supported);
+  gst_d3d11_device_unlock (filter->device);
+
   if (gst_d3d11_result (hr, filter->device)) {
     if ((supported & D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) ==
         D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) {


### PR DESCRIPTION
d3d11debuglayer was reporting next error:

Two threads were found to be executing functions associated with the same Device[Context] at the same time. This will cause corruption of memory. Appropriate thread synchronization needs to occur external to the Direct3D API (or through the ID3D10Multithread interface)

This serie of commits makes this error not be reported anymore.