### PR TITLE
New fixes for the d3d11 plugin

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11bufferpool.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11bufferpool.cpp
@@ -69,35 +69,6 @@ static gboolean gst_d3d11_buffer_pool_start (GstBufferPool * pool);
 static gboolean gst_d3d11_buffer_pool_stop (GstBufferPool * pool);
 
 static void
-gst_d3d11_buffer_pool_set_allocators_blocked (GstD3D11BufferPool *self, gboolean active)
-{
-  GstD3D11BufferPoolPrivate *priv = self->priv;
-  guint i;
-
-  for (i = 0; i < G_N_ELEMENTS (priv->alloc); i++) {
-    if (priv->alloc[i]) {
-      gst_d3d11_pool_allocator_set_blocked(priv->alloc[i], active);
-    }
-  }  
-}
-
-static void
-gst_d3d11_buffer_pool_flush_start (GstBufferPool * bpool)
-{
-  GstD3D11BufferPool *self = GST_D3D11_BUFFER_POOL (bpool);
-
-  gst_d3d11_buffer_pool_set_allocators_blocked (self, TRUE);
-}
-
-static void
-gst_d3d11_buffer_pool_flush_stop (GstBufferPool * bpool)
-{
-  GstD3D11BufferPool *self = GST_D3D11_BUFFER_POOL (bpool);
-
-  gst_d3d11_buffer_pool_set_allocators_blocked(self, FALSE);
-}
-
-static void
 gst_d3d11_buffer_pool_class_init (GstD3D11BufferPoolClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
@@ -110,8 +81,6 @@ gst_d3d11_buffer_pool_class_init (GstD3D11BufferPoolClass * klass)
   bufferpool_class->alloc_buffer = gst_d3d11_buffer_pool_alloc_buffer;
   bufferpool_class->start = gst_d3d11_buffer_pool_start;
   bufferpool_class->stop = gst_d3d11_buffer_pool_stop;
-  bufferpool_class->flush_start = gst_d3d11_buffer_pool_flush_start;
-  bufferpool_class->flush_stop = gst_d3d11_buffer_pool_flush_stop;
 
   GST_DEBUG_CATEGORY_INIT (gst_d3d11_buffer_pool_debug, "d3d11bufferpool", 0,
       "d3d11bufferpool object");

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11converter.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11converter.cpp
@@ -1313,9 +1313,9 @@ gst_d3d11_color_convert_setup_shader (GstD3D11Converter * self,
   memset (input_desc, 0, sizeof (input_desc));
   memset (&buffer_desc, 0, sizeof (buffer_desc));
 
+  GstD3D11DeviceLockGuard lk(device);
   device_handle = gst_d3d11_device_get_device_handle (device);
   context_handle = gst_d3d11_device_get_device_context_handle (device);
-
 
   if(priv->bilinear_filtering) {
     sampler_desc.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
@@ -1418,7 +1418,6 @@ gst_d3d11_color_convert_setup_shader (GstD3D11Converter * self,
     return FALSE;
   }
 
-  GstD3D11DeviceLockGuard lk (device);
   hr = context_handle->Map (const_buffer.Get (), 0, D3D11_MAP_WRITE_DISCARD, 0,
       &map);
   if (!gst_d3d11_result (hr, device)) {
@@ -3001,7 +3000,7 @@ gst_d3d11_converter_setup_processor (GstD3D11Converter * self)
     GST_WARNING_OBJECT (self, "Unknown output DXGI colorspace");
     return FALSE;
   }
-
+  GstD3D11DeviceLockGuard lkd(self->device);
   video_device = gst_d3d11_device_get_video_device_handle (self->device);
   if (!video_device) {
     GST_DEBUG_OBJECT (self, "video device interface is not available");
@@ -3076,7 +3075,6 @@ gst_d3d11_converter_setup_processor (GstD3D11Converter * self)
     return FALSE;
   }
 
-  GstD3D11DeviceLockGuard lk (device);
   /* We don't want auto processing by driver */
   video_context1->VideoProcessorSetStreamAutoProcessingMode
       (processor.Get (), 0, FALSE);

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
@@ -363,6 +363,7 @@ gst_d3d11_allocate_staging_texture (GstD3D11Device * device,
 {
   D3D11_TEXTURE2D_DESC desc = { 0, };
   ID3D11Texture2D *texture = NULL;
+  GstD3D11DeviceLockGuard lk(device);
   ID3D11Device *device_handle = gst_d3d11_device_get_device_handle (device);
   HRESULT hr;
 
@@ -390,6 +391,7 @@ gst_d3d11_memory_map_cpu_access (GstD3D11Memory * dmem, D3D11_MAP map_type)
 {
   GstD3D11MemoryPrivate *priv = dmem->priv;
   HRESULT hr;
+  GstD3D11DeviceLockGuard lk(dmem->device);
   ID3D11DeviceContext *device_context =
       gst_d3d11_device_get_device_context_handle (dmem->device);
 
@@ -415,6 +417,7 @@ gst_d3d11_memory_upload (GstD3D11Memory * dmem)
       !GST_MEMORY_FLAG_IS_SET (dmem, GST_D3D11_MEMORY_TRANSFER_NEED_UPLOAD))
     return;
 
+  GstD3D11DeviceLockGuard lk(dmem->device);
   device_context = gst_d3d11_device_get_device_context_handle (dmem->device);
   device_context->CopySubresourceRegion (priv->texture, priv->subresource_index,
       0, 0, 0, priv->staging, 0, NULL);
@@ -431,6 +434,7 @@ gst_d3d11_memory_download (GstD3D11Memory * dmem)
       !GST_MEMORY_FLAG_IS_SET (dmem, GST_D3D11_MEMORY_TRANSFER_NEED_DOWNLOAD))
     return;
 
+  GstD3D11DeviceLockGuard lk(dmem->device);
   device_context = gst_d3d11_device_get_device_context_handle (dmem->device);
   device_context->CopySubresourceRegion (priv->staging, 0, 0, 0, 0,
       priv->texture, priv->subresource_index, NULL);
@@ -508,6 +512,7 @@ static void
 gst_d3d11_memory_unmap_cpu_access (GstD3D11Memory * dmem)
 {
   GstD3D11MemoryPrivate *priv = dmem->priv;
+  GstD3D11DeviceLockGuard lk(dmem->device);
   ID3D11DeviceContext *device_context =
       gst_d3d11_device_get_device_context_handle (dmem->device);
 
@@ -774,6 +779,7 @@ create_shader_resource_views (GstD3D11Memory * mem)
 
   memset (&resource_desc, 0, sizeof (D3D11_SHADER_RESOURCE_VIEW_DESC));
 
+  GstD3D11DeviceLockGuard lk(mem->device);
   device_handle = gst_d3d11_device_get_device_handle (mem->device);
 
   num_views = gst_d3d11_dxgi_format_get_resource_format (priv->desc.Format,
@@ -904,6 +910,7 @@ create_render_target_views (GstD3D11Memory * mem)
 
   memset (&render_desc, 0, sizeof (D3D11_RENDER_TARGET_VIEW_DESC));
 
+  GstD3D11DeviceLockGuard lk(mem->device);
   device_handle = gst_d3d11_device_get_device_handle (mem->device);
 
   num_views = gst_d3d11_dxgi_format_get_resource_format (priv->desc.Format,
@@ -1363,6 +1370,7 @@ gst_d3d11_memory_copy (GstMemory * mem, gssize offset, gssize size)
   GstD3D11Memory *dmem = GST_D3D11_MEMORY_CAST (mem);
   GstD3D11Memory *copy_dmem;
   GstD3D11Device *device = dmem->device;
+  GstD3D11DeviceLockGuard lk(device);
   ID3D11DeviceContext *device_context =
       gst_d3d11_device_get_device_context_handle (device);
   D3D11_TEXTURE2D_DESC dst_desc = { 0, };
@@ -1378,8 +1386,6 @@ gst_d3d11_memory_copy (GstMemory * mem, gssize offset, gssize size)
     GST_DEBUG_OBJECT (alloc, "Different size/offset, try fallback copy");
     return priv->fallback_copy (mem, offset, size);
   }
-
-  GstD3D11DeviceLockGuard lk (device);
 
   if (!gst_memory_map (mem, &info,
           (GstMapFlags) (GST_MAP_READ | GST_MAP_D3D11))) {
@@ -1541,6 +1547,7 @@ gst_d3d11_allocator_alloc_internal (GstD3D11Allocator * self,
   GstD3D11ClearRTVFunc clear_func = nullptr;
   gboolean is_new_texture = TRUE;
 
+  GstD3D11DeviceLockGuard lk(device);
   device_handle = gst_d3d11_device_get_device_handle (device);
 
   if (!texture) {
@@ -1588,7 +1595,6 @@ gst_d3d11_allocator_alloc_internal (GstD3D11Allocator * self,
     return mem;
 
   context_handle = gst_d3d11_device_get_device_context_handle (device);
-  GstD3D11DeviceLockGuard lk (device);
   clear_func (context_handle, rtv);
 
   return mem;
@@ -1665,6 +1671,7 @@ gst_d3d11_allocator_alloc_buffer (GstD3D11Allocator * allocator,
     return nullptr;
   }
 
+  GstD3D11DeviceLockGuard lk(device);
   device_handle = gst_d3d11_device_get_device_handle (device);
 
   hr = device_handle->CreateBuffer (desc, nullptr, &buffer);
@@ -1914,7 +1921,7 @@ gst_d3d11_pool_allocator_start (GstD3D11PoolAllocator * self)
     priv->started = TRUE;
     return TRUE;
   }
-
+  GstD3D11DeviceLockGuard lk(self->device);
   device_handle = gst_d3d11_device_get_device_handle (self->device);
 
   if (!priv->texture) {

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11convert.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11convert.cpp
@@ -1247,12 +1247,15 @@ gst_d3d11_base_convert_propose_allocation (GstBaseTransform * trans,
     dxgi_format = d3d11_format.dxgi_format;
   }
 
-  device_handle = gst_d3d11_device_get_device_handle (filter->device);
-  hr = device_handle->CheckFormatSupport (dxgi_format, &supported);
-  if (gst_d3d11_result (hr, filter->device) &&
+  {
+    GstD3D11DeviceLockGuard lk(filter->device);
+    device_handle = gst_d3d11_device_get_device_handle(filter->device);
+    hr = device_handle->CheckFormatSupport(dxgi_format, &supported);
+    if (gst_d3d11_result(hr, filter->device) &&
       (supported & D3D11_FORMAT_SUPPORT_RENDER_TARGET) ==
       D3D11_FORMAT_SUPPORT_RENDER_TARGET) {
-    bind_flags |= D3D11_BIND_RENDER_TARGET;
+      bind_flags |= D3D11_BIND_RENDER_TARGET;
+    }
   }
 
   n_pools = gst_query_get_n_allocation_pools (query);
@@ -1369,12 +1372,15 @@ gst_d3d11_base_convert_decide_allocation (GstBaseTransform * trans,
     dxgi_format = d3d11_format.dxgi_format;
   }
 
-  device_handle = gst_d3d11_device_get_device_handle (filter->device);
-  hr = device_handle->CheckFormatSupport (dxgi_format, &supported);
-  if (gst_d3d11_result (hr, filter->device) &&
+  {
+    GstD3D11DeviceLockGuard lk(filter->device);
+    device_handle = gst_d3d11_device_get_device_handle(filter->device);
+    hr = device_handle->CheckFormatSupport(dxgi_format, &supported);
+    if (gst_d3d11_result(hr, filter->device) &&
       (supported & D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) ==
       D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) {
-    bind_flags |= D3D11_BIND_SHADER_RESOURCE;
+      bind_flags |= D3D11_BIND_SHADER_RESOURCE;
+    }
   }
 
   size = GST_VIDEO_INFO_SIZE (&info);

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11decoder.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11decoder.cpp
@@ -321,6 +321,7 @@ gst_d3d11_decoder_constructed (GObject * object)
     return;
   }
 
+  GstD3D11DeviceLockGuard lk(self->device);
   video_device = gst_d3d11_device_get_video_device_handle (self->device);
   if (!video_device) {
     GST_WARNING_OBJECT (self, "ID3D11VideoDevice is not available");
@@ -1513,6 +1514,7 @@ gst_d3d11_decoder_crop_and_copy_buffer (GstD3D11Decoder * self,
     GstBuffer * src, GstBuffer * dst)
 {
   GstD3D11Device *device = self->device;
+  GstD3D11DeviceLockGuard lk(device);
   ID3D11DeviceContext *context =
       gst_d3d11_device_get_device_context_handle (device);
   GstD3D11Memory *src_dmem;
@@ -1551,7 +1553,6 @@ gst_d3d11_decoder_crop_and_copy_buffer (GstD3D11Decoder * self,
   if (!gst_d3d11_decoder_ensure_staging_texture (self))
     return FALSE;
 
-  GstD3D11DeviceLockGuard lk (device);
   if (!gst_video_frame_map (&frame, &self->output_info, dst, GST_MAP_WRITE)) {
     GST_ERROR_OBJECT (self, "Failed to map output buffer");
     return FALSE;

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11overlaycompositor.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11overlaycompositor.cpp
@@ -361,6 +361,7 @@ gst_d3d11_overlay_compositor_setup_shader (GstD3D11OverlayCompositor * self)
   memset (&buffer_desc, 0, sizeof (buffer_desc));
   memset (&blend_desc, 0, sizeof (blend_desc));
 
+  GstD3D11DeviceLockGuard lk(device);
   device_handle = gst_d3d11_device_get_device_handle (device);
   context_handle = gst_d3d11_device_get_device_context_handle (device);
 
@@ -441,7 +442,6 @@ gst_d3d11_overlay_compositor_setup_shader (GstD3D11OverlayCompositor * self)
     return FALSE;
   }
 
-  GstD3D11DeviceLockGuard lk (device);
   hr = context_handle->Map (index_buffer.Get (),
       0, D3D11_MAP_WRITE_DISCARD, 0, &map);
 

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11upload.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11upload.cpp
@@ -333,17 +333,20 @@ gst_d3d11_upload_decide_allocation (GstBaseTransform * trans, GstQuery * query)
     dxgi_format = d3d11_format.dxgi_format;
   }
 
-  device_handle = gst_d3d11_device_get_device_handle (filter->device);
-  hr = device_handle->CheckFormatSupport (dxgi_format, &supported);
-  if (gst_d3d11_result (hr, filter->device)) {
-    if ((supported & D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) ==
+  {
+    GstD3D11DeviceLockGuard lk(filter->device);
+    device_handle = gst_d3d11_device_get_device_handle(filter->device);
+    hr = device_handle->CheckFormatSupport(dxgi_format, &supported);
+    if (gst_d3d11_result(hr, filter->device)) {
+      if ((supported & D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) ==
         D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) {
-      bind_flags |= D3D11_BIND_SHADER_RESOURCE;
-    }
+        bind_flags |= D3D11_BIND_SHADER_RESOURCE;
+      }
 
-    if ((supported & D3D11_FORMAT_SUPPORT_RENDER_TARGET) ==
+      if ((supported & D3D11_FORMAT_SUPPORT_RENDER_TARGET) ==
         D3D11_FORMAT_SUPPORT_RENDER_TARGET) {
-      bind_flags |= D3D11_BIND_RENDER_TARGET;
+        bind_flags |= D3D11_BIND_RENDER_TARGET;
+      }
     }
   }
 

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11window.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11window.cpp
@@ -577,6 +577,7 @@ gst_d3d11_window_prepare_default (GstD3D11Window * window, guint display_width,
    * Otherwise, use DXGI_FORMAT_B8G8R8A8_UNORM or DXGI_FORMAT_B8G8R8A8_UNORM
    */
   gst_video_info_from_caps (&window->info, caps);
+  GstD3D11DeviceLockGuard lkd(device);
   device_handle = gst_d3d11_device_get_device_handle (device);
   for (guint i = 0; i < G_N_ELEMENTS (formats); i++) {
     hr = device_handle->CheckFormatSupport (formats[i].dxgi_format,


### PR DESCRIPTION
- avoid "GPU Suspended" error by adding missing device locks
- refactor d3d11bufferpool allocator to avoid "infinite loop issue" in the acquire function