### PR TITLE
d3d11window_win32: fix crash on RC unprepare vs WM_PAINT

### DIFF
--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11window_win32.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11window_win32.cpp
@@ -65,6 +65,7 @@ struct _GstD3D11WindowWin32
 
   SRWLOCK lock;
   CONDITION_VARIABLE cond;
+  GRecMutex hwnds_lock;
 
   GMainContext *main_context;
   GMainLoop *loop;
@@ -105,7 +106,7 @@ G_DEFINE_TYPE (GstD3D11WindowWin32, gst_d3d11_window_win32,
     GST_TYPE_D3D11_WINDOW);
 
 static void gst_d3d11_window_win32_constructed (GObject * object);
-static void gst_d3d11_window_win32_dispose (GObject * object);
+static void gst_d3d11_window_win32_finalize (GObject * object);
 
 static void gst_d3d11_window_win32_show (GstD3D11Window * window);
 static void gst_d3d11_window_win32_update_swap_chain (GstD3D11Window * window);
@@ -149,7 +150,7 @@ gst_d3d11_window_win32_class_init (GstD3D11WindowWin32Class * klass)
   GstD3D11WindowClass *window_class = GST_D3D11_WINDOW_CLASS (klass);
 
   gobject_class->constructed = gst_d3d11_window_win32_constructed;
-  gobject_class->dispose = gst_d3d11_window_win32_dispose;
+  gobject_class->finalize = gst_d3d11_window_win32_finalize;
 
   window_class->show = GST_DEBUG_FUNCPTR (gst_d3d11_window_win32_show);
   window_class->update_swap_chain =
@@ -177,6 +178,7 @@ static void
 gst_d3d11_window_win32_init (GstD3D11WindowWin32 * self)
 {
   self->main_context = g_main_context_new ();
+  g_rec_mutex_init (&self->hwnds_lock);
 }
 
 static void
@@ -205,10 +207,13 @@ done:
 }
 
 static void
-gst_d3d11_window_win32_dispose (GObject * object)
+gst_d3d11_window_win32_finalize (GObject * object)
 {
+  GstD3D11WindowWin32* self = GST_D3D11_WINDOW_WIN32(object);
+
   GST_DEBUG_OBJECT (object, "dispose");
   gst_d3d11_window_win32_unprepare (GST_D3D11_WINDOW (object));
+  g_rec_mutex_clear (&self->hwnds_lock);
   G_OBJECT_CLASS (parent_class)->dispose (object);
 }
 
@@ -287,9 +292,13 @@ gst_d3d11_window_win32_unprepare (GstD3D11Window * window)
           0, 0);
     }
 
+    /* Hold hwnds lock to allow the window thread finish processing what it could
+     * already have in the queue at this moment, before we reset the handlers to null */
+    g_rec_mutex_lock (&self->hwnds_lock);
     self->external_hwnd = NULL;
     self->internal_hwnd = NULL;
     self->internal_hwnd_thread = NULL;
+    g_rec_mutex_unlock (&self->hwnds_lock);
   }
 
   if (self->loop) {
@@ -885,10 +894,19 @@ window_proc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     SetPropA (hWnd, D3D11_WINDOW_PROP_NAME, self);
   } else if ((self = gst_d3d11_window_win32_hwnd_get_instance (hWnd))) {
-    g_assert (self->internal_hwnd == hWnd);
+    g_rec_mutex_lock (&self->hwnds_lock);
+    if (self->internal_hwnd == nullptr) {
+      /* self instance is already in the destruction proccess, just
+       * let it process WM_GST_D3D11_DESTROY_INTERNAL_WINDOW */
+      g_rec_mutex_unlock (&self->hwnds_lock);
+      gst_object_unref (self);
+      return DefWindowProcA (hWnd, uMsg, wParam, lParam);
+    }
 
+    g_assert (self->internal_hwnd == hWnd);
     gst_d3d11_window_win32_handle_window_proc (self, hWnd, uMsg, wParam,
         lParam);
+    g_rec_mutex_unlock (&self->hwnds_lock);
 
     switch (uMsg) {
       case WM_SIZE:


### PR DESCRIPTION
Unprepare method posts WM_GST_D3D11_DESTROY_INTERNAL_WINDOW command to the window queue, and from that moment considers internal_hwnd to be released, and so it sets it to null. The problem is that it's possible that right at that moment the window thread might be already processing some other command, or just another command might be already in the queue. On practice we met a crash when WM_PAINT got processed in between (unprepare already finished and WM_GST_D3D11_DESTROY_INTERNAL_WINDOW was not handled yet)