### PR TITLE
d3d11d2d1: cache d2d1 brushes + corrify factory storage

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11_fwd.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11_fwd.h
@@ -30,6 +30,7 @@
 
 #include <d3d11.h>
 #include <dxgi.h>
+#include <d2d1.h>
 
 G_BEGIN_DECLS
 

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11device.h
@@ -119,6 +119,9 @@ gboolean              gst_d3d11_device_get_format         (GstD3D11Device * devi
                                                            GstVideoFormat format,
                                                            GstD3D11Format * device_format);
 
+GST_D3D11_API
+ID2D1Factory*         gst_d3d11_device_get_d2d1_factory   (GstD3D11Device * device);
+
 /* Used internally by gstd3d11utils.cpp */
 void                  gst_d3d11_device_mark_suspended     (GstD3D11Device* device);
 

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.cpp
@@ -340,6 +340,7 @@ struct _GstD3D11MemoryPrivate
 
   IDXGISurface* dxgi_surface;
   ID2D1RenderTarget* d2d1_render_target;
+  GHashTable *d2d1_rt_resources_cache;
 };
 
 static inline D3D11_MAP
@@ -1335,6 +1336,27 @@ ID2D1RenderTarget* gst_d3d11_memory_get_d2d1_render_target (GstD3D11Memory* mem,
     return render_target;
 }
 
+GHashTable *
+gst_d3d11_memory_get_d2d1_brushes_cache (GstMemory* mem)
+{
+  GstD3D11MemoryPrivate *priv;
+  g_return_val_if_fail (gst_is_d3d11_memory (mem), NULL);
+  priv = GST_D3D11_MEMORY_CAST (mem)->priv;  
+  g_return_val_if_fail (priv->d2d1_render_target, NULL);
+
+  if (!priv->d2d1_rt_resources_cache) {
+    auto free_com = [] (gpointer com)
+    {
+      ((IUnknown *)com)->Release ();
+    };
+    
+    priv->d2d1_rt_resources_cache = g_hash_table_new_full (g_str_hash,
+        g_str_equal, g_free, free_com);
+  }
+
+  return priv->d2d1_rt_resources_cache;
+}
+
 /* GstD3D11Allocator */
 struct _GstD3D11AllocatorPrivate
 {
@@ -1475,6 +1497,9 @@ gst_d3d11_allocator_free (GstAllocator * allocator, GstMemory * mem)
     GST_D3D11_CLEAR_COM (dmem_priv->decoder_output_view);
     GST_D3D11_CLEAR_COM (dmem_priv->processor_input_view);
     GST_D3D11_CLEAR_COM (dmem_priv->processor_output_view);
+
+    if (dmem_priv->d2d1_rt_resources_cache)
+      g_hash_table_unref (dmem_priv->d2d1_rt_resources_cache);
     GST_D3D11_CLEAR_COM (dmem_priv->dxgi_surface);
     GST_D3D11_CLEAR_COM (dmem_priv->d2d1_render_target);
     GST_D3D11_CLEAR_COM (dmem_priv->texture);

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/gstd3d11memory.h
@@ -250,11 +250,12 @@ ID3D11VideoProcessorOutputView *  gst_d3d11_memory_get_processor_output_view (Gs
                                                                               ID3D11VideoDevice * video_device,
                                                                               ID3D11VideoProcessorEnumerator * enumerator);
 
-
 GST_D3D11_API
 ID2D1RenderTarget* gst_d3d11_memory_get_d2d1_render_target (GstD3D11Memory * mem,
                                                             ID2D1Factory * factory);
 
+GST_D3D11_API
+GHashTable *gst_d3d11_memory_get_d2d1_brushes_cache (GstMemory* mem);
 
 /**
  * GstD3D11Allocator:

--- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
@@ -43,10 +43,11 @@ d3d11_conf = configuration_data()
 
 d3d11_lib = cc.find_library('d3d11', required : false)
 dxgi_lib = cc.find_library('dxgi', required : false)
+d2d1_lib = cc.find_library('d2d1', required : false)
 d3dcompiler_lib = cc.find_library('d3dcompiler', required: false)
 runtimeobject_lib = cc.find_library('runtimeobject', required : false)
 
-if not d3d11_lib.found() or not dxgi_lib.found()
+if not d3d11_lib.found() or not dxgi_lib.found() or not d2d1_lib.found()
   subdir_done()
 endif
 
@@ -183,11 +184,11 @@ gstd3d11 = library('gstd3d11-' + api_version,
   version : libversion,
   soversion : soversion,
   install : true,
-  dependencies : [gstbase_dep, gstvideo_dep, gmodule_dep, d3d11_lib, dxgi_lib] + extra_deps
+  dependencies : [gstbase_dep, gstvideo_dep, gmodule_dep, d3d11_lib, dxgi_lib, d2d1_lib] + extra_deps
 )
 
 pkgconfig.generate(gstd3d11,
-  libraries : [gstbase_dep, gstvideo_dep, d3d11_lib, dxgi_lib],
+  libraries : [gstbase_dep, gstvideo_dep, d3d11_lib, dxgi_lib, d2d1_lib],
   variables : pkgconfig_variables,
   subdirs : pkgconfig_subdirs,
   extra_cflags : ['-I${libdir}/gstreamer-1.0/include'],
@@ -208,7 +209,7 @@ if build_gir
     'includes' : gir_includes,
     'install' : true,
     'extra_args' : gir_init_section + ['-DGST_USE_UNSTABLE_API'],
-    'dependencies' : [gstbase_dep, gstvideo_dep, d3d11_lib, dxgi_lib],
+    'dependencies' : [gstbase_dep, gstvideo_dep, d3d11_lib, dxgi_lib, d2d1_lib],
   }
   if not static_build
     d3d11_gir = gnome.generate_gir(gstd3d11, kwargs: gir)
@@ -223,7 +224,7 @@ install_headers(d3d11_headers, subdir : 'gstreamer-1.0/gst/d3d11')
 
 gstd3d11_dep = declare_dependency(link_with : gstd3d11,
   include_directories : [libsinc],
-  dependencies : [gstbase_dep, gstvideo_dep, d3d11_lib, dxgi_lib],
+  dependencies : [gstbase_dep, gstvideo_dep, d3d11_lib, dxgi_lib, d2d1_lib],
   sources : gen_sources)
 
 meson.override_dependency(pkg_name, gstd3d11_dep)

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11d2d1.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11d2d1.cpp
@@ -60,7 +60,6 @@
 #endif
 
 #include <gst/gst.h>
-#include <d2d1.h>
 #include "gstd3d11d2d1.h"
 /* Filter signals and args */
 enum
@@ -176,19 +175,13 @@ gst_d3d11_d2d1_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 
   dmem = GST_D3D11_MEMORY_CAST (mem);
   GstD3D11DeviceLockGuard lk (filter->device);
-  static ID2D1Factory* direct2DFactory;
+  ID2D1Factory* direct2DFactory = gst_d3d11_device_get_d2d1_factory (filter->device);
   if (!direct2DFactory) {
-    hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED,
-			   &direct2DFactory);
-    
-    if (!gst_d3d11_result(hr, filter->device)) {
-      GST_ERROR_OBJECT (filter,
-	  "Could not create ID2D1Factory, hr: 0x%x", (guint)hr);
-      return GST_FLOW_ERROR;
-    }
+    GST_ERROR_OBJECT (filter, "Could not get ID2D1Factory");
+    return GST_FLOW_ERROR;
   }
 
-  render_target = gst_d3d11_memory_get_d2d1_render_target(dmem, direct2DFactory);
+  render_target = gst_d3d11_memory_get_d2d1_render_target (dmem, direct2DFactory);
   if (render_target == NULL) {
     GST_ERROR_OBJECT(filter,
 	"Could not get ID2D1RenderTarget from d3d11memory");

--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11d2d1.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11d2d1.cpp
@@ -155,7 +155,7 @@ gst_d3d11_d2d1_class_init (Gstd3d11d2d1Class * klass)
   gst_d3d11_d2d1_signals[SIGNAL_DRAW] =
       g_signal_new("draw", G_TYPE_FROM_CLASS(klass),
           G_SIGNAL_RUN_FIRST, 0, NULL, NULL, NULL, G_TYPE_NONE, 2,
-          G_TYPE_POINTER, G_TYPE_UINT64);
+          G_TYPE_POINTER, GST_TYPE_BUFFER);
 }
 
 static GstFlowReturn
@@ -189,8 +189,7 @@ gst_d3d11_d2d1_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
   }
 
   GST_DEBUG_OBJECT(filter, "Emit signal to the user");
-  g_signal_emit(filter, gst_d3d11_d2d1_signals[SIGNAL_DRAW], 0, render_target, GST_BUFFER_PTS (buf));
-
+  g_signal_emit(filter, gst_d3d11_d2d1_signals[SIGNAL_DRAW], 0, render_target, buf);
   return GST_FLOW_OK;
 }
 

--- a/subprojects/gst-plugins-bad/sys/d3d11/meson.build
+++ b/subprojects/gst-plugins-bad/sys/d3d11/meson.build
@@ -19,6 +19,7 @@ d3d11_sources = [
   'gstd3d11vp9dec.cpp',
   'gstd3d11window.cpp',
   'gstd3d11window_dummy.cpp',
+  'gstd3d11d2d1.cpp',
   'plugin.cpp',
 ]
 
@@ -36,13 +37,6 @@ if not gstd3d11_dep.found() or not cc.has_header('dxva.h') or not cc.has_header(
     error('The d3d11 was enabled explicitly, but required dependencies were not found.')
   endif
   subdir_done()
-endif
-
-d2d1_lib = cc.find_library('d2d1', required: false)
-if cc.has_header('d2d1.h') and d2d1_lib.found()
-  extra_dep += [d2d1_lib]
-  d3d11_sources += ['gstd3d11d2d1.cpp']
-  extra_args += ['-DHAVE_D2D1']
 endif
 
 d3dcompiler_lib = cc.find_library('d3dcompiler', required: d3d11_option)

--- a/subprojects/gst-plugins-bad/sys/d3d11/plugin.cpp
+++ b/subprojects/gst-plugins-bad/sys/d3d11/plugin.cpp
@@ -88,9 +88,7 @@
 using namespace Microsoft::WRL;
 /* *INDENT-ON* */
 
-#ifdef HAVE_D2D1
 #include "gstd3d11d2d1.h"
-#endif
 
 GST_DEBUG_CATEGORY (gst_d3d11_debug);
 GST_DEBUG_CATEGORY (gst_d3d11_plugin_utils_debug);
@@ -116,9 +114,7 @@ GST_DEBUG_CATEGORY (gst_d3d11_screen_capture_device_debug);
 
 
 
-#ifdef HAVE_D2D1
 GST_DEBUG_CATEGORY(gst_d3d11_d2d1_debug);
-#endif
 
 #define GST_CAT_DEFAULT gst_d3d11_debug
 
@@ -171,10 +167,8 @@ plugin_init (GstPlugin * plugin)
   if (FAILED (hr))
     return TRUE;
 
-#ifdef HAVE_D2D1
   GST_DEBUG_CATEGORY_INIT(gst_d3d11_d2d1_debug,
       "d3d11d2d1", 0, "d3d11d2d1 element");
-#endif
 
   /* Enumerate devices to register decoders per device and to get the highest
    * feature level */
@@ -272,10 +266,8 @@ plugin_init (GstPlugin * plugin)
   }
 #endif
 
-#ifdef HAVE_D2D1
   gst_element_register(plugin,
       "d3d11d2d1", GST_RANK_NONE, GST_TYPE_D3D11D2D1);
-#endif
 
   return TRUE;
 }


### PR DESCRIPTION
Brushes caching:
Now we provide a GstBuffer in the "draw" signal, and introduce gst_d3d11_memory_get_d2d1_brushes_cache()
call, that allows us to cache previously created D2D1 brushes. This improves the performance and also makes the
use of D2D1 more correct.

Factory storage:

Before we were storing one ID2D1Factory for all the instances of the d2d1 element. But it seems to be dangerous due to this article:
https://learn.microsoft.com/en-us/windows/win32/direct2d/multi-threaded-direct2d-apps#developing-thread-safe-direct2d-apps-with-minimal-direct3d-or-dxgi-calls

If we have one ID2D1Factory for all, then we can't protect it with the device lock, so we decide to attach it to the GstD3D11Device object. We assume that underneath some d2d1 calls there might be access to the ID2D1Factory, and it might collide with other DXGI calls, so we are going to make sure the factory is always protected with the device lock too.