### PR TITLE
Changes to modify H264 parsing warnings to debug  messages.

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gsth264parser.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gsth264parser.c
@@ -1109,7 +1109,7 @@ gst_h264_parser_parse_user_data_unregistered (GstH264NalParser * nalparser,
 
   data = g_malloc0 (payload_size);
   for (i = 0; i < payload_size; ++i) {
-    READ_UINT8 (nr, data[i], 8);
+    VICON_READ_UINT8 (nr, data[i], 8);
   }
 
   if (payload_size < 1) {
@@ -1124,7 +1124,7 @@ gst_h264_parser_parse_user_data_unregistered (GstH264NalParser * nalparser,
 
 error:
   {
-    GST_WARNING ("error parsing \"User Data Unregistered\"");
+    GST_DEBUG ("error parsing \"User Data Unregistered\"");
     g_clear_pointer (&data, g_free);
     return GST_H264_PARSER_ERROR;
   }

--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/nalutils.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/nalutils.h
@@ -137,6 +137,13 @@ gboolean nal_reader_get_se (NalReader * nr, gint32 * val);
   } \
 }
 
+#define VICON_READ_UINT8(nr, val, nbits) { \
+  if (!nal_reader_get_bits_uint8 (nr, &val, nbits)) { \
+    GST_DEBUG ("failed to read uint8 for '" G_STRINGIFY (val) "', nbits: %d", nbits); \
+    goto error; \
+  } \
+}
+
 #define READ_UINT16(nr, val, nbits) { \
   if (!nal_reader_get_bits_uint16 (nr, &val, nbits)) { \
   GST_WARNING ("failed to read uint16 for '" G_STRINGIFY (val) "', nbits: %d", nbits); \

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
@@ -635,7 +635,7 @@ gst_h264_parse_process_sei (GstH264Parse * h264parse, GstH264NalUnit * nalu)
 
   pres = gst_h264_parser_parse_sei (nalparser, nalu, &messages);
   if (pres != GST_H264_PARSER_OK)
-    GST_WARNING_OBJECT (h264parse, "failed to parse one or more SEI message");
+    GST_DEBUG_OBJECT (h264parse, "failed to parse one or more SEI message");
 
   /* Even if pres != GST_H264_PARSER_OK, some message could have been parsed and
    * stored in messages.


### PR DESCRIPTION
Changed following warnings to debug messages.

-> WARN       codecparsers_h264 gsth264parser.c:1112:gst_h264_parser_parse_user_data_unregistered: failed to read uint8 for 'data[i]', nbits: 8
-> WARN       codecparsers_h264 gsth264parser.c:1127:gst_h264_parser_parse_user_data_unregistered: error parsing "User Data Unregistered"
-> WARN               h264parse gsth264parse.c:638:gst_h264_parse_process_sei:<parser_player_session_id_67218> failed to parse one or more SEI message